### PR TITLE
Compatibility TYPO3 11.5

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -4,4 +4,7 @@ plugin.tx_solr {
         partialRootPath = EXT:headless_solr/Resources/Private/Solr/Partials/
         layoutRootPath = EXT:headless_solr/Resources/Private/Solr/Layouts/
     }
+    settings {
+        searchPid =
+    }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,3 +1,9 @@
+plugin.tx_solr {
+    settings {
+        searchPid = {$plugin.tx_solr.settings.searchPid}
+    }
+}
+
 tt_content.list =< lib.contentElementWithHeader
 tt_content.list {
     fields {

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -4,6 +4,18 @@ plugin.tx_solr {
     }
 }
 
+lib.tx_solr.sys_category_title = RECORDS
+lib.tx_solr.sys_category_title {
+    source.current = 1
+    tables = sys_category
+    dontCheckPid = 1
+    conf {
+        sys_category = TEXT
+        sys_category.field = title
+        sys_category.htmlSpecialChars = 1
+    }
+}
+
 tt_content.list =< lib.contentElementWithHeader
 tt_content.list {
     fields {

--- a/Resources/Private/Solr/Partials/Facets/Hierarchy.html
+++ b/Resources/Private/Solr/Partials/Facets/Hierarchy.html
@@ -19,6 +19,7 @@
 					value: childNode.label,
 					label: '{f:cObject(typoscriptObjectPath:\'lib.tx_solr.sys_category_title\',data:childNode.label)}',
 					count: childNode.documentCount,
+					active: childNode.selected,
 					uri: {
 						set: '{s:uri.facet.addFacetItem(facet: facet, facetItem: childNode)}',
 						unset: '{s:uri.facet.removeFacetItem(facet: facet, facetItem: childNode)}'

--- a/Resources/Private/Solr/Partials/Facets/Hierarchy.html
+++ b/Resources/Private/Solr/Partials/Facets/Hierarchy.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		options: '{f:render(section:\'hierarchyTree\',arguments:\'{node:facet,facet:facet}\') -> headless:format.json.decode()}'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/Hierarchy.html
+++ b/Resources/Private/Solr/Partials/Facets/Hierarchy.html
@@ -7,6 +7,24 @@
 <f:format.raw>
 	<f:format.json value="{
 		label: facet.label,
-		todo: 'facet type \'hierarchy\' has not been implemented yet!'
+		options: '{f:render(section:\'hierarchyTree\',arguments:\'{node:facet,facet:facet}\') -> headless:format.json.decode()}'
 	}" />
 </f:format.raw>
+
+<f:section name="hierarchyTree">
+	<f:format.raw>
+		[
+			<f:for each="{node.childNodes}" as="childNode" iteration="iterator">
+				<f:format.json value="{
+					value: childNode.label,
+					label: '{f:cObject(typoscriptObjectPath:\'lib.tx_solr.sys_category_title\',data:childNode.label)}',
+					count: childNode.documentCount,
+					uri: '{s:uri.facet.addFacetItem(facet: facet, facetItem: childNode)}',
+					children: '{f:render(section:\'hierarchyTree\',arguments:\'{node:childNode,facet:facet}\') -> headless:format.json.decode()}'
+				}" />
+				<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
+
+			</f:for>
+		]
+	</f:format.raw>
+</f:section>

--- a/Resources/Private/Solr/Partials/Facets/Hierarchy.html
+++ b/Resources/Private/Solr/Partials/Facets/Hierarchy.html
@@ -19,7 +19,10 @@
 					value: childNode.label,
 					label: '{f:cObject(typoscriptObjectPath:\'lib.tx_solr.sys_category_title\',data:childNode.label)}',
 					count: childNode.documentCount,
-					uri: '{s:uri.facet.addFacetItem(facet: facet, facetItem: childNode)}',
+					uri: {
+						set: '{s:uri.facet.addFacetItem(facet: facet, facetItem: childNode)}',
+						unset: '{s:uri.facet.removeFacetItem(facet: facet, facetItem: childNode)}'
+					},
 					children: '{f:render(section:\'hierarchyTree\',arguments:\'{node:childNode,facet:facet}\') -> headless:format.json.decode()}'
 				}" />
 				<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>

--- a/Resources/Private/Solr/Partials/Facets/Hierarchy.html
+++ b/Resources/Private/Solr/Partials/Facets/Hierarchy.html
@@ -20,7 +20,7 @@
 					label: '{f:cObject(typoscriptObjectPath:\'lib.tx_solr.sys_category_title\',data:childNode.label)}',
 					count: childNode.documentCount,
 					active: childNode.selected,
-					uri: {
+					uris: {
 						set: '{s:uri.facet.addFacetItem(facet: facet, facetItem: childNode)}',
 						unset: '{s:uri.facet.removeFacetItem(facet: facet, facetItem: childNode)}'
 					},

--- a/Resources/Private/Solr/Partials/Facets/Hierarchy.html
+++ b/Resources/Private/Solr/Partials/Facets/Hierarchy.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'hierarchy\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/Options.html
+++ b/Resources/Private/Solr/Partials/Facets/Options.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		options: '{f:render(section:\'options\',arguments:\'{facet:facet}\') -> headless:format.json.decode()}'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/Options.html
+++ b/Resources/Private/Solr/Partials/Facets/Options.html
@@ -1,0 +1,28 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		options: '{f:render(section:\'options\',arguments:\'{facet:facet}\') -> headless:format.json.decode()}'
+	}" />
+</f:format.raw>
+
+<f:section name="options">
+	<f:format.raw>
+		[
+			<f:for each="{facet.options}" as="option" iteration="iterator">
+				<f:format.json value="{
+					value: option.value,
+					label: option.label,
+					count: option.documentCount,
+					uri: '{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}'
+				}" />
+				<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
+			</f:for>
+		]
+	</f:format.raw>
+</f:section>

--- a/Resources/Private/Solr/Partials/Facets/Options.html
+++ b/Resources/Private/Solr/Partials/Facets/Options.html
@@ -19,6 +19,7 @@
 					value: option.value,
 					label: option.label,
 					count: option.documentCount,
+					active: option.selected,
 					uris: {
 						set: '{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}',
 						unset: '{s:uri.facet.removeFacetItem(facet: facet, facetItem: option)}'

--- a/Resources/Private/Solr/Partials/Facets/Options.html
+++ b/Resources/Private/Solr/Partials/Facets/Options.html
@@ -19,7 +19,10 @@
 					value: option.value,
 					label: option.label,
 					count: option.documentCount,
-					uri: '{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}'
+					uris: {
+						set: '{s:uri.facet.addFacetItem(facet: facet, facetItem: option)}',
+						unset: '{s:uri.facet.removeFacetItem(facet: facet, facetItem: option)}'
+					}
 				}" />
 				<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
 			</f:for>

--- a/Resources/Private/Solr/Partials/Facets/OptionsFiltered.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsFiltered.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'options filtered\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsFiltered.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsFiltered.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'options filtered\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsPrefixGrouped.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsPrefixGrouped.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'options prefix grouped\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsPrefixGrouped.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsPrefixGrouped.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'options prefix grouped\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsSinglemode.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsSinglemode.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'options singlemode\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsSinglemode.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsSinglemode.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'options singlemode\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsToggle.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsToggle.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'options toggle\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/OptionsToggle.html
+++ b/Resources/Private/Solr/Partials/Facets/OptionsToggle.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'options toggle\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/RangeDate.html
+++ b/Resources/Private/Solr/Partials/Facets/RangeDate.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'range date\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/RangeDate.html
+++ b/Resources/Private/Solr/Partials/Facets/RangeDate.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'range date\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/RangeNumeric.html
+++ b/Resources/Private/Solr/Partials/Facets/RangeNumeric.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'range numeric\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/RangeNumeric.html
+++ b/Resources/Private/Solr/Partials/Facets/RangeNumeric.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'range numeric\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/Rootline.html
+++ b/Resources/Private/Solr/Partials/Facets/Rootline.html
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:format.raw>
+	<f:format.json value="{
+		label: facet.label,
+		todo: 'facet type \'rootline\' has not been implemented yet!'
+	}" />
+</f:format.raw>

--- a/Resources/Private/Solr/Partials/Facets/Rootline.html
+++ b/Resources/Private/Solr/Partials/Facets/Rootline.html
@@ -6,7 +6,7 @@
 
 <f:format.raw>
 	<f:format.json value="{
-		label: facet.label,
+		label: '{f:translate(key:facet.label,default:facet.label)}',
 		todo: 'facet type \'rootline\' has not been implemented yet!'
 	}" />
 </f:format.raw>

--- a/Resources/Private/Solr/Partials/Result/Document.html
+++ b/Resources/Private/Solr/Partials/Result/Document.html
@@ -14,7 +14,6 @@
 						<f:format.json value="{
 							uid: searchResult.fields.uid,
 							pid: searchResult.fields.pid,
-							typeNum: searchResult.fields.typeNum,
 							site: searchResult.fields.site,
 							type: searchResult.fields.type,
 							title: searchResult.fields.title,
@@ -24,7 +23,7 @@
 							author: searchResult.fields.author,
 							content: searchResult.fields.content,
 							contentExact: searchResult.fields.contentExact,
-							url: '{searchResult.fields.url -> headless:format.json.decode()}'
+							url: searchResult.fields.url
 						  }"/>
 						</f:format.raw>
 						{f:if(condition: iterator.isLast, else: ',')}

--- a/Resources/Private/Solr/Partials/Result/Document.html
+++ b/Resources/Private/Solr/Partials/Result/Document.html
@@ -5,30 +5,32 @@
 <f:section name="Document">
 	<f:spaceless>
 		<f:if condition="{resultSet.hasSearched}">
-			{"pagination": <s:widget.resultPaginate resultSet="{resultSet}">
-			,"list": {
-			"count": {resultSet.searchResults -> f:count()}
-			,"results": [<f:for each="{resultSet.searchResults}" as="searchResult" iteration="iterator">
-				<f:format.raw>
-				<f:format.json value="{
-					uid: searchResult.fields.uid,
-					pid: searchResult.fields.pid,
-					typeNum: searchResult.fields.typeNum,
-					site: searchResult.fields.site,
-					type: searchResult.fields.type,
-					title: searchResult.fields.title,
-					titleExact: searchResult.fields.titleExact,
-					subTitle: searchResult.fields.subTitle,
-					navTitle: searchResult.fields.navTitle,
-					author: searchResult.fields.author,
-					content: searchResult.fields.content,
-					contentExact: searchResult.fields.contentExact,
-					url: '{searchResult.fields.url -> headless:format.json.decode()}'
-				  }"/>
-				</f:format.raw>
-				{f:if(condition: iterator.isLast, else: ',')}
-		</f:for>]}
-			</s:widget.resultPaginate>}
+			{
+				"pagination": <f:render partial="Result/Pagination" section="Pagination" arguments="{currentPage:currentPage,pagination:pagination,resultSet:resultSet}" />,
+				"list": {
+					"count": {resultSet.searchResults -> f:count()},
+					"results": [<f:for each="{resultSet.searchResults}" as="searchResult" iteration="iterator">
+						<f:format.raw>
+						<f:format.json value="{
+							uid: searchResult.fields.uid,
+							pid: searchResult.fields.pid,
+							typeNum: searchResult.fields.typeNum,
+							site: searchResult.fields.site,
+							type: searchResult.fields.type,
+							title: searchResult.fields.title,
+							titleExact: searchResult.fields.titleExact,
+							subTitle: searchResult.fields.subTitle,
+							navTitle: searchResult.fields.navTitle,
+							author: searchResult.fields.author,
+							content: searchResult.fields.content,
+							contentExact: searchResult.fields.contentExact,
+							url: '{searchResult.fields.url -> headless:format.json.decode()}'
+						  }"/>
+						</f:format.raw>
+						{f:if(condition: iterator.isLast, else: ',')}
+					</f:for>]
+				}
+			}
 		</f:if>
 	</f:spaceless>
 </f:section>

--- a/Resources/Private/Solr/Partials/Result/Document.html
+++ b/Resources/Private/Solr/Partials/Result/Document.html
@@ -14,6 +14,8 @@
 						<f:format.json value="{
 							uid: searchResult.fields.uid,
 							pid: searchResult.fields.pid,
+							created: searchResult.fields.created,
+							changed: searchResult.fields.changed,
 							site: searchResult.fields.site,
 							type: searchResult.fields.type,
 							title: searchResult.fields.title,

--- a/Resources/Private/Solr/Partials/Result/Facets.html
+++ b/Resources/Private/Solr/Partials/Result/Facets.html
@@ -1,0 +1,14 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+      data-namespace-typo3-fluid="true"
+>
+
+<s:facet.area.group groupName="main" facets="{resultSet.facets.available}">
+	[
+		<f:for each="{areaFacets}" as="facet" iteration="iterator">
+			<f:render partial="Facets/{facet.partialName}" arguments="{resultSet:resultSet, facet:facet}"/>
+			<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
+		</f:for>
+	]
+</s:facet.area.group>

--- a/Resources/Private/Solr/Partials/Result/Pagination.html
+++ b/Resources/Private/Solr/Partials/Result/Pagination.html
@@ -1,0 +1,26 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
+
+<f:section name="Pagination">
+	<f:spaceless>
+		<f:format.raw>
+			{
+				"current":  <f:format.json value="{currentPage}" />,
+				"previous": <f:format.json value="{pagination.previousPageNumber}" />,
+				"next":     <f:format.json value="{pagination.nextPageNumber}" />,
+				"links": [
+					<f:for each="{pagination.allPageNumbers}" as="page" iteration="iterator">
+						{
+							"link": <f:format.json value="{s:uri.paginate.resultPage(page: page)}" />,
+							"active": <f:format.json value="{f:if(condition:'{currentPage} == {iterator.cycle}',then:'true',else:'false') -> headless:format.json.decode()}" />
+						}
+						{f:if(condition: iterator.isLast, else: ',')}
+					</f:for>
+				]
+			}
+		</f:format.raw>
+	</f:spaceless>
+</f:section>

--- a/Resources/Private/Solr/Partials/Result/Sorting.html
+++ b/Resources/Private/Solr/Partials/Result/Sorting.html
@@ -1,39 +1,48 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers">
+	  xmlns:s="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	  data-namespace-typo3-fluid="true"
+>
 
-<f:section name="Sorting">
-			<f:for each="{resultSet.sortings}" as="sorting">
-
-				<f:if condition="{sorting.isResetOption}">
+[
+	<f:for each="{resultSet.sortings}" as="sorting" iteration="iterator">
+		<f:if condition="{sorting.isResetOption}">
+			<f:then>
+				<f:format.raw>
+					<f:format.json value="{
+						type: 'reset',
+						uri: '{s:uri.sorting.removeSorting()}',
+						label: sorting.label
+					}" />
+				</f:format.raw>
+			</f:then>
+			<f:else>
+				<f:if condition="{sorting.selected}">
 					<f:then>
-						<li>
-							<a href="{s:uri.sorting.removeSorting()}" class="solr-ajaxified">{sorting.label}</a>
-						</li>
+						<f:format.raw>
+							<f:format.json value="{
+								type: 'default',
+								active: 1,
+								direction: '{f:if(condition:sorting.isAscDirection,then:\'asc\',else:\'desc\')}',
+								uri: '{s:uri.sorting.setSorting(sortingName: sorting.name, sortingDirection: sorting.oppositeDirection)}',
+								label: sorting.label
+							}" />
+						</f:format.raw>
 					</f:then>
-
 					<f:else>
-						<f:if condition="{sorting.selected}">
-							<f:then>
-								<li class="active">
-									<a href="{s:uri.sorting.setSorting(sortingName: sorting.name, sortingDirection: sorting.oppositeDirection)}" class="solr-ajaxified">
-										<f:if condition="{sorting.isAscDirection}">
-											<f:then><span class=" glyphicon glyphicon-arrow-up pull-right"></span></f:then>
-											<f:else><span class=" glyphicon glyphicon-arrow-down pull-right"></span></f:else>
-										</f:if>
-										<span>{sorting.label}</span>
-
-									</a>
-								</li>
-							</f:then>
-							<f:else>
-								<li>
-									<a href="{s:uri.sorting.setSorting(sortingName: sorting.name, sortingDirection: sorting.direction)}" class="solr-ajaxified">{sorting.label}</a>
-								</li>
-							</f:else>
-						</f:if>
+						<f:format.raw>
+							<f:format.json value="{
+								type: 'default',
+								active: 0,
+								direction: null,
+								uri: '{s:uri.sorting.setSorting(sortingName: sorting.name, sortingDirection: sorting.direction)}',
+								label: sorting.label
+							}" />
+						</f:format.raw>
 					</f:else>
-			</f:if>
-
-			</f:for>
-</f:section>
+				</f:if>
+			</f:else>
+		</f:if>
+		<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
+	</f:for>
+]

--- a/Resources/Private/Solr/Partials/Search/Form.html
+++ b/Resources/Private/Solr/Partials/Search/Form.html
@@ -1,16 +1,18 @@
 <f:section name="Form">
 <f:spaceless>
-	<f:format.raw>
-		<f:format.json value="{
+    <f:variable name="searchUri" value="{f:uri.page(pageUid:settings.searchPid,pageType:7383)}" />
+    <f:variable name="suggestUri" value="{f:uri.page(pageUid:settings.searchPid,pageType:7384)}" />
+    <f:format.raw>
+        <f:format.json value="{
               additionalFilters: additionalFilters,
               existingParameters: existingParameters,
               pluginNamespace: pluginNamespace,
               name: 'q',
               value: arguments.q,
-              pageUid: pageUid,
-              languageUid: languageUid,
-              query: q
-		  }"/>
-	</f:format.raw>
+              query: q,
+              searchUri: searchUri,
+              suggestUri: suggestUri
+          }"/>
+    </f:format.raw>
 </f:spaceless>
 </f:section>

--- a/Resources/Private/Solr/Partials/Search/Form.html
+++ b/Resources/Private/Solr/Partials/Search/Form.html
@@ -5,8 +5,8 @@
               additionalFilters: additionalFilters,
               existingParameters: existingParameters,
               pluginNamespace: pluginNamespace,
-              name: name,
-              value: value,
+              name: 'q',
+              value: arguments.q,
               pageUid: pageUid,
               languageUid: languageUid,
               query: q

--- a/Resources/Private/Solr/Templates/Search/Results.html
+++ b/Resources/Private/Solr/Templates/Search/Results.html
@@ -8,12 +8,13 @@
 	<f:spaceless>
 		<f:format.raw>
 			<f:format.json value="{
-              form: '{f:render(partial: \'Search/Form\', section: \'Form\', arguments: \'{search:search, additionalFilters:additionalFilters, pluginNamespace: pluginNamespace, resultSet: resultSet}\') -> headless:format.json.decode()}',
-              documents: '{f:render(partial: \'Result/Document\', section: \'Document\', arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
-              resultPerPage: '{f:render(partial: \'Result/PerPage\', section: \'PerPage\', arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
-              allResultCount: resultSet.allResultCount,
-			  currentSearch: '{s:uri.search.currentSearch()}',
-			  arguments: arguments.q
+				form: '{f:render(partial: \'Search/Form\', section: \'Form\', arguments: \'{arguments:arguments, additionalFilters:additionalFilters, pluginNamespace: pluginNamespace}\') -> headless:format.json.decode()}',
+				documents: '{f:render(partial: \'Result/Document\', section: \'Document\', arguments: \'{currentPage:currentPage,pagination:pagination,resultSet:resultSet}\') -> headless:format.json.decode()}',
+				resultPerPage: '{f:render(partial: \'Result/PerPage\', section: \'PerPage\', arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
+				allResultCount: resultSet.allResultCount,
+				resultsPerPage: resultSet.usedResultsPerPage,
+				currentSearch: '{s:uri.search.currentSearch()}',
+				arguments: arguments.q
 		  }"/>
 		</f:format.raw>
 	</f:spaceless>

--- a/Resources/Private/Solr/Templates/Search/Results.html
+++ b/Resources/Private/Solr/Templates/Search/Results.html
@@ -10,6 +10,7 @@
 			<f:format.json value="{
 				form: '{f:render(partial: \'Search/Form\', section: \'Form\', arguments: \'{arguments:arguments, additionalFilters:additionalFilters, pluginNamespace: pluginNamespace}\') -> headless:format.json.decode()}',
 				facets: '{f:render(partial: \'Result/Facets.html\',arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
+				sorting: '{f:render(partial: \'Result/Sorting.html\',arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
 				documents: '{f:render(partial: \'Result/Document\', section: \'Document\', arguments: \'{currentPage:currentPage,pagination:pagination,resultSet:resultSet}\') -> headless:format.json.decode()}',
 				resultPerPage: '{f:render(partial: \'Result/PerPage\', section: \'PerPage\', arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
 				allResultCount: resultSet.allResultCount,

--- a/Resources/Private/Solr/Templates/Search/Results.html
+++ b/Resources/Private/Solr/Templates/Search/Results.html
@@ -9,6 +9,7 @@
 		<f:format.raw>
 			<f:format.json value="{
 				form: '{f:render(partial: \'Search/Form\', section: \'Form\', arguments: \'{arguments:arguments, additionalFilters:additionalFilters, pluginNamespace: pluginNamespace}\') -> headless:format.json.decode()}',
+				facets: '{f:render(partial: \'Result/Facets.html\',arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
 				documents: '{f:render(partial: \'Result/Document\', section: \'Document\', arguments: \'{currentPage:currentPage,pagination:pagination,resultSet:resultSet}\') -> headless:format.json.decode()}',
 				resultPerPage: '{f:render(partial: \'Result/PerPage\', section: \'PerPage\', arguments: \'{resultSet:resultSet}\') -> headless:format.json.decode()}',
 				allResultCount: resultSet.allResultCount,

--- a/Resources/Private/Solr/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
+++ b/Resources/Private/Solr/Templates/ViewHelpers/Widget/ResultPaginate/Index.html
@@ -1,9 +1,0 @@
-<f:spaceless>
-	<f:format.raw>
-		<f:format.json value="{
-             current: contentArguments.pagination.current,
-             numberOfPages: contentArguments.pagination.numberOfPages
-       }"/>
-	</f:format.raw>
-</f:spaceless>
-<f:renderChildren arguments="{contentArguments}" />

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^9.5 || ^10.0"
+    "typo3/cms-core": "^11.5"
   },
   "suggest": {
     "friendsoftypo3/headless": "^2.0"


### PR DESCRIPTION
This adds support for TYPO3 11.5 and drops the support for the versions below.

A working version of EXT:solr hasn't been released yet: https://packagist.org/packages/apache-solr-for-typo3/solr#dev-release-11.5.x

The biggest part of this PR was switching from the old pagination widget to the new mechanism.

And I've added basic support for facets: only "Options" and "Hierarchy" are working at the moment.

Resolves: #4 