### PR TITLE
Add TYPO3 v12 support

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,11 +1,14 @@
 <?php
-defined('TYPO3_MODE') || die();
 
-call_user_func(function () {
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') || die();
+
+call_user_func(static function () {
     /**
-     * Default TypoScript for Headless Solr
+     * Default TypoScript for Headless_solr
      */
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    ExtensionManagementUtility::addStaticFile(
         'headless_solr',
         'Configuration/TypoScript',
         'Headless Solr'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This extension provides integration to headless extension with solr extension.
 If you have any questions just drop a line in #initiative-pwa Slack channel.
 
 ## Requirements
-Extension requires TYPO3 in version at least 9.5.
+Extension requires TYPO3 in version at least 11.5 or 12.4.
 
 ## Installation
 Install extension using composer\

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^11.5"
+    "typo3/cms-core": "^11.5 || ^12.4"
   },
   "suggest": {
-    "friendsoftypo3/headless": "^2.0"
+    "friendsoftypo3/headless": "^2.0 || ^4.0"
   },
   "extra": {
     "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,11 +8,11 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'extensions@macopedia.com',
     'category' => 'fe',
     'internal' => '',
-    'version' => '2.0.0',
+    'version' => '3.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.0.99-11.9.99',
-            'frontend' => '10.0.99-11.9.99'
+            'typo3' => '11.0.99-12.9.99',
+            'frontend' => '11.0.99-12.9.99'
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
Hello,

i added a few changes to make this work on the followed speccs:

- TYPO3  v12.4.9
- friendsoftypo3/headless  v4.2.3
- PHP 8.2.11

![image](https://github.com/TYPO3-Headless/headless_solr/assets/10448557/5c8adba2-445f-456d-9c08-0771d752d581)

Maybe this helps. If you got any questions just ask :) 

Best regards
Fabio